### PR TITLE
Update gatling.conf

### DIFF
--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -40,7 +40,7 @@ gatling {
     }
     directory {
       #data = user-files/data                    # Folder where user's data (e.g. files used by Feeders) is located
-      #requestBodies = user-files/request-bodies # Folder where request bodies are located
+      bodies = src/test/resource/bodies          # Folder where request bodies are located
       #simulations = user-files/simulations      # Folder where the bundle's simulations are located
       #reportsOnly = ""                          # If set, name of report folder to look for in order to generate its report
       #binaries = ""                             # If set, name of the folder where compiles classes are located


### PR DESCRIPTION
'requestBodies' should be 'bodies' and needs to point to correct location for sbt project. The recorder by default drops the files here.