### PR TITLE
[docs] Remove SBT version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Gatling's SBT plugin demo
 
 A simple project showing how to configure and use Gatling's SBT plugin to run Gatling simulations. 
 
-This project uses SBT 0.13.12, which is available [here](http://www.scala-sbt.org/download.html) or through [Paul Phillips's sbt-extras script](https://github.com/paulp/sbt-extras).
+This project uses [SBT](http://www.scala-sbt.org/download.html) or through [Paul Phillips's sbt-extras script](https://github.com/paulp/sbt-extras).
 
 Get the project
 ---------------


### PR DESCRIPTION
The readme SBT version was out of date, but I don't think we need to update both the version number in the code and the docs. 